### PR TITLE
Description filter defaults to ignore case

### DIFF
--- a/Electron/package.json
+++ b/Electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventlogexpert",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "author": {
     "name": "Microsoft"
   },


### PR DESCRIPTION
Fixes #67. This change adds regex support. If the Description
filter starts with /, then we try to parse it as a regex.
Otherwise we create a regex that performs a case-insensitive
match on the provided string.