### PR TITLE
Fix build failure

### DIFF
--- a/Electron/package.json
+++ b/Electron/package.json
@@ -68,7 +68,7 @@
     "rxjs": "6.1.0",
     "ts-node": "6.0.3",
     "tslint": "5.10.0",
-    "typescript": "2.7.2",
+    "typescript": "^3.1.4",
     "wait-on": "2.1.0",
     "webdriver-manager": "12.0.6",
     "zone.js": "0.8.26"


### PR DESCRIPTION
Build failing with error:

```
> tsc --lib es6,dom main.ts

node_modules/builder-util-runtime/out/httpExecutor.d.ts(25,39): error TS1039: Initializers are not allowed in ambient contexts.
```

Updating typescript appears to fix this.