### PR TITLE
Split large files across multiple windows #131

### DIFF
--- a/Electron/.gitignore
+++ b/Electron/.gitignore
@@ -52,3 +52,6 @@ package-lock.json
 # System Files
 .DS_Store
 Thumbs.db
+
+# My stuff
+eventutils

--- a/Electron/eventlogexpert.menu.ts
+++ b/Electron/eventlogexpert.menu.ts
@@ -7,7 +7,7 @@ import * as log from 'electron-log';
 
 export class EventLogExpertMenu {
 
-  constructor(private windowManager: EventLogExpertWindowManager) {
+  constructor(private windowManager: EventLogExpertWindowManager, private maxEventsPerWindow: number) {
     this.createMenu();
   }
 
@@ -118,9 +118,9 @@ export class EventLogExpertMenu {
 
       if (!this.windowManager.hasOpenLog(window)) {
         this.windowManager.setOpenLog(window, files.filePaths[0]);
-        window.webContents.send('openLogFromFile', files.filePaths[0], null);
+        window.webContents.send('openLogFromFile', { file: files.filePaths[0], start: 0, count: this.maxEventsPerWindow, tzName: null });
       } else {
-        const newWindow = this.windowManager.createWindow(files.filePaths[0]);
+        const newWindow = this.windowManager.createWindow(files.filePaths[0], 0, this.maxEventsPerWindow, null);
       }
     });
   }

--- a/Electron/eventlogexpert.windowmanager.ts
+++ b/Electron/eventlogexpert.windowmanager.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, screen, app } from 'electron';
+import { BrowserWindow, screen, app, ipcMain } from 'electron';
 import * as isDev from 'electron-is-dev';
 import * as url from 'url';
 import * as path from 'path';
@@ -9,9 +9,12 @@ export class EventLogExpertWindowManager {
 
     constructor(private serve: boolean) {
         this.openWindows = [];
+        ipcMain.on('openPartialEventLog', (ev, args) => {
+            this.createWindow(args.file, args.start, args.count, args.tzName);
+        });
     }
 
-    public createWindow(log: string): BrowserWindow {
+    public createWindow(log: string, start: number, count: number, tzName: string): BrowserWindow {
         const electronScreen = screen;
         const size = electronScreen.getPrimaryDisplay().workAreaSize;
 
@@ -63,7 +66,7 @@ export class EventLogExpertWindowManager {
         this.openWindows.push({ window: win, openLog: log });
         if (log) {
             win.webContents.once('dom-ready', () => {
-                win.webContents.send('openLogFromFile', log, null);
+                win.webContents.send('openLogFromFile', { file: log, start: start, count: count, tzName: tzName });
             });
         }
         return win;

--- a/Electron/main.ts
+++ b/Electron/main.ts
@@ -9,8 +9,9 @@ let serve;
 const args = process.argv.slice(1);
 serve = args.some(val => val === '--serve');
 
+const maxEventsPerWindow = 1500000;
 const windowManager = new EventLogExpertWindowManager(serve);
-const menuBar = new EventLogExpertMenu(windowManager);
+const menuBar = new EventLogExpertMenu(windowManager, maxEventsPerWindow);
 
 try {
 
@@ -21,7 +22,7 @@ try {
     app.on('second-instance', (event, commandLine, workingDirectory) => {
       log.info(commandLine);
       if (commandLine.length >= 3) {
-        const newWindow = windowManager.createWindow(commandLine[2]);
+        const newWindow = windowManager.createWindow(commandLine[2], 0, maxEventsPerWindow, null);
       } else {
         windowManager.focus();
       }
@@ -34,9 +35,9 @@ try {
     // Some APIs can only be used after this event occurs.
     app.on('ready', () => {
       if (process.argv.length >= 2) {
-        windowManager.createWindow(process.argv[1]);
+        windowManager.createWindow(process.argv[1], 0, maxEventsPerWindow, null);
       } else {
-        windowManager.createWindow(null);
+        windowManager.createWindow(null, 0, maxEventsPerWindow, null);
       }
       autoUpdater.logger = log;
       log.transports.file.level = 'debug';
@@ -56,7 +57,7 @@ try {
       // On OS X it's common to re-create a window in the app when the
       // dock icon is clicked and there are no other windows open.
       if (windowManager.windowCount() === 0) {
-        const win = windowManager.createWindow(null);
+        const win = windowManager.createWindow(null, 0, maxEventsPerWindow, null);
       }
     });
   }

--- a/Electron/package.json
+++ b/Electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventlogexpert",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "author": {
     "name": "Bill Long"
   },

--- a/Electron/src/app/components/home/home.component.html
+++ b/Electron/src/app/components/home/home.component.html
@@ -14,7 +14,9 @@
   <div class="detail-divider" (mousedown)="onDetailDividerMouseDown($event)"></div>
   <app-event-detail [hidden]="!state.focusedEvent" [ngStyle]="{ 'height': detailHeight + 'px' }" [heightChange$]="detailHeightChange$"></app-event-detail>
   <div class="status-bar">
-    <div *ngIf="state.records.length">Records: {{state.records.length}}</div>
+    <div *ngIf="state.records.length && state.records.length != state.count">Loaded: {{state.records.length}}</div>
     <div *ngIf="state.recordsFiltered.length">Visible: {{state.recordsFiltered.length}}</div>
+    <div>Start Offset: {{state.start}}</div>
+    <div>Event Count: {{state.count}}</div>
   </div>
 </div>

--- a/Electron/src/app/components/tagsmodal/tagsmodal.component.ts
+++ b/Electron/src/app/components/tagsmodal/tagsmodal.component.ts
@@ -46,9 +46,14 @@ export class TagsmodalComponent implements OnInit {
     this.tags$ = dbService.tagsByPriority$;
     this.tags$.subscribe(t => this.displayedTags = [...t]);
     electronSvc.ipcRenderer.on('openLogFromFile',
-      (ev, file) => {
-        this.visible = true;
-        this.onSave = () => this.eventLogService.actions$.next(new LoadLogFromFileAction(file));
+      (ev, options: { file: string, start: number, count: number, tzName: string }) => {
+        if (!options.tzName) {
+          this.visible = true;
+          this.onSave = () => this.eventLogService.actions$.next(new LoadLogFromFileAction(options.file, options.start, options.count));
+        } else {
+          this.eventLogService.setTimeZone(options.tzName);
+          this.eventLogService.actions$.next(new LoadLogFromFileAction(options.file, options.start, options.count));
+        }
       });
   }
 

--- a/Electron/src/app/providers/eventlog/eventlog.actions.ts
+++ b/Electron/src/app/providers/eventlog/eventlog.actions.ts
@@ -45,7 +45,7 @@ export class LoadActiveLogAction {
 export class LoadLogFromFileAction {
     type = 'LOAD_LOG_FROM_FILE';
 
-    constructor(public file: string) { }
+    constructor(public file: string, public start: number, public count: number) { }
 }
 
 export class FocusEventAction {
@@ -72,6 +72,12 @@ export class ShiftSelectEventAction {
     constructor(public e: EventRecord) { }
 }
 
+export class UpdateCountAction {
+    type = 'UPDATE_COUNT';
+
+    constructor(public c: number) { }
+}
+
 export type Action =
     ClearEventsAction |
     EventsLoadedAction |
@@ -83,4 +89,5 @@ export type Action =
     LoadActiveLogAction |
     LoadLogFromFileAction |
     SelectEventAction |
-    ShiftSelectEventAction;
+    ShiftSelectEventAction |
+    UpdateCountAction;

--- a/Electron/src/app/providers/eventlog/eventlog.state.ts
+++ b/Electron/src/app/providers/eventlog/eventlog.state.ts
@@ -1,13 +1,15 @@
 import { EventRecord } from './eventlog.models';
 import { EventLogService } from './eventlog.service';
 import { AppConfig } from '../../../environments/environment';
-import { Action, EventsLoadedAction, FilterEventsAction, FilterEventsFinishedAction, FinishedLoadingAction, FocusEventAction, LoadActiveLogAction, LoadLogFromFileAction, SelectEventAction, ShiftSelectEventAction } from './eventlog.actions';
+import { Action, EventsLoadedAction, FilterEventsAction, FilterEventsFinishedAction, FinishedLoadingAction, FocusEventAction, LoadActiveLogAction, LoadLogFromFileAction, SelectEventAction, ShiftSelectEventAction, UpdateCountAction } from './eventlog.actions';
 
 // State
 
 export interface State {
     loading: boolean;
     name: string;
+    start: number;
+    count: number;
     records: EventRecord[];
     recordsFiltered: EventRecord[];
     focusedEvent: EventRecord;
@@ -53,6 +55,8 @@ export const reducer = (state: State, action: Action): State => {
             return {
                 loading: false,
                 name: state.name,
+                start: state.start,
+                count: state.count,
                 records: [],
                 recordsFiltered: [],
                 focusedEvent: null,
@@ -68,6 +72,8 @@ export const reducer = (state: State, action: Action): State => {
             return {
                 loading: true,
                 name: state.name,
+                start: state.start,
+                count: state.count,
                 records: records,
                 recordsFiltered: records,
                 focusedEvent: state.focusedEvent,
@@ -82,6 +88,8 @@ export const reducer = (state: State, action: Action): State => {
             return {
                 loading: state.loading,
                 name: state.name,
+                start: state.start,
+                count: state.count,
                 records: state.records,
                 recordsFiltered: state.recordsFiltered,
                 focusedEvent: state.focusedEvent,
@@ -96,6 +104,8 @@ export const reducer = (state: State, action: Action): State => {
             return {
                 loading: state.loading,
                 name: state.name,
+                start: state.start,
+                count: state.count,
                 records: state.records,
                 recordsFiltered: thisAction.filteredRecords,
                 focusedEvent: state.focusedEvent,
@@ -125,6 +135,8 @@ export const reducer = (state: State, action: Action): State => {
             return {
                 loading: false,
                 name: state.name,
+                start: state.start,
+                count: state.count,
                 records: records,
                 recordsFiltered: records,
                 focusedEvent: state.focusedEvent,
@@ -143,6 +155,8 @@ export const reducer = (state: State, action: Action): State => {
             return {
                 loading: true,
                 name: thisAction.logName,
+                start: state.start,
+                count: state.count,
                 records: [],
                 recordsFiltered: [],
                 focusedEvent: state.focusedEvent,
@@ -157,6 +171,8 @@ export const reducer = (state: State, action: Action): State => {
             return {
                 loading: true,
                 name: thisAction.file,
+                start: thisAction.start,
+                count: thisAction.count,
                 records: [],
                 recordsFiltered: [],
                 focusedEvent: state.focusedEvent,
@@ -171,6 +187,8 @@ export const reducer = (state: State, action: Action): State => {
             return {
                 loading: state.loading,
                 name: state.name,
+                start: state.start,
+                count: state.count,
                 records: state.records,
                 recordsFiltered: state.recordsFiltered,
                 focusedEvent: thisAction.e,
@@ -185,6 +203,8 @@ export const reducer = (state: State, action: Action): State => {
             return {
                 loading: state.loading,
                 name: state.name,
+                start: state.start,
+                count: state.count,
                 records: state.records,
                 recordsFiltered: state.recordsFiltered,
                 focusedEvent: null,
@@ -203,6 +223,8 @@ export const reducer = (state: State, action: Action): State => {
             return {
                 loading: state.loading,
                 name: state.name,
+                start: state.start,
+                count: state.count,
                 records: state.records,
                 recordsFiltered: state.recordsFiltered,
                 focusedEvent: state.focusedEvent,
@@ -232,10 +254,28 @@ export const reducer = (state: State, action: Action): State => {
             return {
                 loading: state.loading,
                 name: state.name,
+                start: state.start,
+                count: state.count,
                 records: state.records,
                 recordsFiltered: state.recordsFiltered,
                 focusedEvent: state.focusedEvent,
                 selectedEvents: newSelectedEvents,
+                filter: state.filter,
+                sort: state.sort,
+                uniqueRecordValues: state.uniqueRecordValues
+            };
+        }
+        case 'UPDATE_COUNT': {
+            const thisAction = action as UpdateCountAction;
+            return {
+                loading: state.loading,
+                name: state.name,
+                start: state.start,
+                count: thisAction.c,
+                records: state.records,
+                recordsFiltered: state.recordsFiltered,
+                focusedEvent: state.focusedEvent,
+                selectedEvents: state.selectedEvents,
                 filter: state.filter,
                 sort: state.sort,
                 uniqueRecordValues: state.uniqueRecordValues

--- a/Electron/src/app/providers/eventutils.service.ts
+++ b/Electron/src/app/providers/eventutils.service.ts
@@ -14,6 +14,12 @@ export class EventUtils {
         methodName: 'GetActiveEventLogReader'
     });
 
+    getEventLogRecordCount = this.electronSvc.edge.func({
+        assemblyFile: this.electronSvc.extraResourcesPath + 'eventutils/EventLogExpert.dll',
+        typeName: 'EventLogExpert.EventReader',
+        methodName: 'GetEventLogRecordCount'
+    });
+
     getEventLogFileReader = this.electronSvc.edge.func({
         assemblyFile: this.electronSvc.extraResourcesPath + 'eventutils/EventLogExpert.dll',
         typeName: 'EventLogExpert.EventReader',

--- a/EventUtils/.gitignore
+++ b/EventUtils/.gitignore
@@ -238,3 +238,6 @@ _Pvt_Extensions
 
 # FAKE - F# Make
 .fake/
+
+# My stuff
+.vscode


### PR DESCRIPTION
When loading an event log that has more than 1.5 million events, we split them across multiple windows, with a maximum of 1.5 million events in each window. All windows load from the log simultaneously. The goal is to prevent us from exhausting the V8 JS memory limit of 4 GB, which applies per window.

While loading, the status bars look like this:

![image](https://user-images.githubusercontent.com/4518572/134827281-473a2179-99eb-4e14-aeb1-0f4b429c405e.png)

* Loaded - number of events read from the file so far
* Visible - number of events visible with the current filter
* Start Offset - the offset of the event we started at, such as 0 for the beginning of the file.
* Event Count - the number of events we intend to load into this window.

Once we have loaded all the events we wanted to, "Loaded" disappears.